### PR TITLE
cast bytearray arguments to int

### DIFF
--- a/SimpleCreateSimulation.py
+++ b/SimpleCreateSimulation.py
@@ -138,7 +138,7 @@ class CreateSim(object):
             
                 p = bytearray(struct.pack(">5BhBh2B", 19, 10, 7, self._bump, 19, dist, 20, ang, 18, 0))
                 #Checksum
-                p.append(0x100 - (np.sum(p[1:]) % 0x100))
+                p.append(int(0x100 - (np.sum(p[1:]) % 0x100)))
             
             self.Packets.fire(p)
                                         


### PR DESCRIPTION
bytearray.append expects integer type arguments and the modulo operation returns a float so this line errors on my system. Simple fix would be to cast the entire argument to an integer type.